### PR TITLE
Added ascending sort to table conversion

### DIFF
--- a/ModifyBmsTableRank.ps1
+++ b/ModifyBmsTableRank.ps1
@@ -121,4 +121,4 @@ if (!(Test-Path -LiteralPath $destinationFilePath))
 	New-Item -Path $destinationFilePath -ItemType File -Force | Out-Null
 }
 
-$modifiedJsonItems | ConvertTo-Json | Out-File ($destination + '\score.json')
+$modifiedJsonItems | Sort { [int]$_.level } | ConvertTo-Json | Out-File ($destination + '\score.json')


### PR DESCRIPTION
The script did not sort a #RANK-convert table when exporting to a file. Currently the table will be sorted simply by level in ascending.