### PR TITLE
Added SHA256 support

### DIFF
--- a/ModifyBmsRank.ps1
+++ b/ModifyBmsRank.ps1
@@ -135,9 +135,19 @@ foreach ($bmsFile in $targetBmsFiles)
 	{
 		$completeConvertingCount = $completeConvertingCount + 1
 		
-		$sourceMd5Hash = Get-FileHash -Algorithm MD5 -LiteralPath $bmsFile.FullName
-		$destinationMd5Hash = Get-FileHash -Algorithm MD5 -LiteralPath $destinationFilePath
-		$convertDetails.Add(@{source = $sourceMd5Hash.Hash; destination = $destinationMd5Hash.Hash})
+		$sourceMd5Hash         = Get-FileHash -Algorithm MD5 -LiteralPath $bmsFile.FullName
+		$sourceSha256Hash      = Get-FileHash -Algorithm SHA256 -LiteralPath $bmsFile.FullName
+		$destinationMd5Hash    = Get-FileHash -Algorithm MD5 -LiteralPath $destinationFilePath
+		$destinationSha256Hash = Get-FileHash -Algorithm SHA256 -LiteralPath $destinationFilePath
+		
+		$convertDetails.Add(
+			@{
+				sourceMd5         = $sourceMd5Hash.Hash        ;
+				destinationMd5    = $destinationMd5Hash.Hash   ;
+				sourceSha256      = $sourceSha256Hash.Hash     ;
+				destinationSha256 = $destinationSha256Hash.Hash
+			}
+		)
 	}
 
 	$currentFileCount = $currentFileCount + 1


### PR DESCRIPTION
- The #RANK modifier generates a json file MD5 hashes as before, and now also SHA256 ones. The table converter replaces old SHA256 hashes with new ones if available.
- Added a validation for existences pointed by given paths.